### PR TITLE
BEPlayer: fix messing with player ranges if infinite is disabled

### DIFF
--- a/BEPlayer.cs
+++ b/BEPlayer.cs
@@ -44,13 +44,27 @@ namespace BuilderEssentials
 
         public override void PostUpdateEquips()
         {
-            Player.tileRangeX = InfinitePlayerRange ? Main.screenWidth / 16 / 2 + 5 : 5;
-            Player.tileRangeY = InfinitePlayerRange ? Main.screenHeight / 16 / 2 + 4 : 4;
-            player.blockRange = InfinitePlacementRange ? Main.screenWidth / 16 / 2 + 5 : 0;
-            player.wallSpeed = FastPlacement ? player.wallSpeed + 10 : 1;
-            player.tileSpeed = FastPlacement ? player.tileSpeed + 50 : 1;
-            Player.defaultItemGrabRange =
-                InfinitePickupRange ? 1000000 : 38; //I have no idea how much it should be so that should suffice??
+            if (InfinitePlayerRange)
+            {
+                Player.tileRangeX = Main.screenWidth / 16 / 2 + 5;
+                Player.tileRangeY = Main.screenHeight / 16 / 2 + 4;
+            }
+
+            if (InfinitePlacementRange)
+            {
+                player.blockRange = Main.screenWidth / 16 / 2 + 5;
+            }
+
+            if (FastPlacement)
+            {
+                player.wallSpeed = player.wallSpeed + 10;
+                player.tileSpeed = player.tileSpeed + 50;
+            }
+
+            if (InfinitePickupRange)
+            {
+                Player.defaultItemGrabRange = 1000000;
+            }
         }
 
         public override void OnEnterWorld(Player player)

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
 displayName = Builder Essentials
 author = Kirtle, Strunter
-version = 1.0
+version = 1.1
 buildIgnore = *.csproj, *.user, obj\*, bin\*, .vs\*
 homepage = https://discord.gg/wQYMbQq


### PR DESCRIPTION
This fixes BuildEssentials overriding any other updates, such as builder
potions or the extendo-grip, with fixed values if the infinite range
features are disabled.

This should play nice with any other mod, as well as the base game.